### PR TITLE
Bernie's changes

### DIFF
--- a/diceImport.js
+++ b/diceImport.js
@@ -19,28 +19,13 @@ $(document).ready(function(){
                 case "download":
                     download_resume();
                     break;
-                case "filename":
-					// only fire if we are the intended tab
-					if (message.candidate_name === candidate_info.name) {
-						candidate_info["resume_file"] = message.filename;
-						import_profile(candidate_info);
-					}
+				case "redirect":
+                    redirect_to_notes();
                     break;
             }
         }  
     );
 });
-
-
-// downloads candidate info as XML and redirects to import link
-function import_profile(candidate_info) {
-    // download xml
-    // download_xml(obj_to_xml(candidate_info));
-
-    // redirect
-    let notes_url = "notes:///8525644700814E57/C371775EAC5E88788525639E007B03A6/3A553EB348165344852585FB00783986";
-    window.location.href = notes_url;    
-}
 
 
 // downloads the resume file
@@ -108,7 +93,7 @@ function scrape() {
     // use parsed email first, and the scraped mail second, unless it is a Dice private email
     if (parsed_info.email) {
 		info["email"] = parsed_info.email;
-		if (!(/\.dice\./.test(scraped_email)) && (scraped_email !== parsed_info.email))  {
+		if (!(/\.dice\./.test(scraped_email)) && (scraped_email.toLowerCase() !== parsed_info.email.toLowerCase()))  {
 			info["email2"] = scraped_email;
 		}
 	} else {

--- a/monsterImport.js
+++ b/monsterImport.js
@@ -12,12 +12,8 @@ $(document).ready(function(){
                 case "download":
                     download_resume();
                     break;
-                case "filename":
-					// only fire if we are the intended tab
-					if (message.candidate_name === candidate_info.name) {
-						candidate_info["resume_file"] = message.filename;
-						import_profile(candidate_info);
-					}
+				case "redirect":
+                    redirect_to_notes();
                     break;
             }
         }
@@ -29,18 +25,6 @@ $(document).ready(function(){
 function download_resume() {
     $(".svg-icon__download").click();
 }
-
-
-// downloads candidate info as XML and redirects to import link
-function import_profile(candidate_info) {
-    // download xml
-    // download_xml(obj_to_xml(candidate_info));
-    
-    // redirect
-    let notes_url = "notes:///8525644700814E57/C371775EAC5E88788525639E007B03A6/3A553EB348165344852585FB00783986";
-    window.location.href = notes_url;    
-}
-
 
 
 // extracts all info from profile page
@@ -88,7 +72,7 @@ function scrape() {
     if (!info.email) {
         info.email = parsed_info.email;
     } else {
-		if ((parsed_info.email !== "") & (parsed_info.email !== info.email)) {
+		if ((parsed_info.email !== "") & (parsed_info.email.toLowerCase() !== info.email.toLowerCase())) {
 			info["email2"] = parsed_info.email;
 		}
 	}	

--- a/popup.js
+++ b/popup.js
@@ -11,7 +11,7 @@ $("#run_btn").click(function(element) {
 			$("#text").show();
 		} else {
       xml_str = response;
-			candidate_name = response.match(/(?<=<name>).*(?=<\/name>)/)[0];
+
 			if (debugMode) {
 				$("#text").text(response);
 				$("#run_btn").text("Try again");

--- a/utils.js
+++ b/utils.js
@@ -34,6 +34,11 @@ function parse_from_resume(text) {
     return parsed_info;
 }
 
+// redirects to the notes protocol URL for the import document
+function redirect_to_notes() {
+	let notes_url ="notes:///8525644700814E57/C371775EAC5E88788525639E007B03A6/3A553EB348165344852585FB00783986";
+	window.location.href = notes_url;
+}	
 
 // download the given xml string into an xml file
 function download_xml(xml_str) {


### PR DESCRIPTION
Followed  your lead re: the onDeterminingFilename callback running much of the download show, rather than delegating to the content scripts.

I tried to clarify the two separate handlers that you had within that callback to manage the resume download and the XML download.  I created a state variable that controls what gets run when the callback is invoked.

I stopped passing the candidate name around, since we no longer need it.

To redirect to notes, rather than sending the message everywhere, I just remembered what the ID of the "real" active tab was, and sent the message there.   I moved the handler for that to utils.js, since it is common to both importers.  I changed the message name to "redirect", since it has nothing to do with the filename anymore.

Changed the filename that gets stuffed into the xml to exclude the directory name

Made the email address comparisons case insensitive

